### PR TITLE
DATABASE_URL の情報を追記

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -28,18 +28,26 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get changed files and run Prettier
+        id: prettier
         run: |
           git fetch origin ${{ github.base_ref }}
-          git diff --name-only origin/${{ github.base_ref }}...HEAD \
-          | grep -E "${{ env.FILE_PATTERN }}" \
-          | xargs npx prettier --write
-          if [ -s changed_files.txt ]; then
-            cat changed_files.txt | xargs npx prettier --write
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E "${{ env.FILE_PATTERN }}" || true)
+
+          if [ -n "$CHANGED" ]; then
+            echo "$CHANGED" | xargs npx prettier --write
+          else
+            echo 'No matching files to format.'
+          fi
+
+          if git diff --quiet; then
+            echo "formatted=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "formatted=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit Prettier changes
         uses: stefanzweifel/git-auto-commit-action@v3
-        if: github.actor != 'github-actions[bot]'
+        if: steps.prettier.outputs.formatted == 'true' && github.actor != 'github-actions[bot]'
         with:
           commit_message: Apply Prettier Change
           branch: ${{ github.head_ref }}

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,7 @@ MySQL データベースを用意し、.env ファイルに接続情報を設定
 - ユーザー: root
 - パスワード: password
 - データベース: gourmet
+- DATABASE_URL=mysql://USER:PASSWORD@HOST:PORT/DATABASE
 
 ## API エンドポイント
 


### PR DESCRIPTION
# 概要
- DATABASE_URL の情報を追記
- フォーマットするファイルがない時 github actions が失敗するため調整

# 変更内容
- steps オブジェクトで参照する際に、id が必要なため定義
- 一致するファイルがなくても失敗しないように `|| true` を追加
    - github actions は終了ステータス 0 以外が帰ってきたら問答無用で失敗と判定するため
- フォーマットされたファイルがない場合コミットしないように調整

参考：[steps オブジェクトで過去に実行したステップの情報を取得できる](https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#steps-context)
参考：[GITHUB_OUTPUT について](https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated backend README to clarify the required format for the database connection URL using the `DATABASE_URL` environment variable.

- **Chores**
  - Improved the automated code formatting workflow to only run and commit formatting changes when necessary, reducing unnecessary commits and providing clearer feedback in the workflow logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->