### PR TITLE
価格帯の表示エラーを解消

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,7 +20,7 @@
           hide-details
           density="compact"
           style="max-width: 150px; margin-right: 10px"
-          @update:modelValue="reloadMapTrigger++"
+          @change="reloadMapTrigger++"
         />
 
         <v-select
@@ -33,7 +33,7 @@
           hide-details
           density="compact"
           style="max-width: 150px; margin-right: 10px"
-          @update:modelValue="reloadMapTrigger++"
+          @change="reloadMapTrigger++"
         />
 
         <v-select
@@ -46,7 +46,7 @@
           hide-details
           density="compact"
           style="max-width: 150px; margin-right: 10px"
-          @update:modelValue="reloadMapTrigger++"
+          @change="reloadMapTrigger++"
         />
 
         <v-checkbox
@@ -85,12 +85,11 @@ import { genreOptions, reasonOptions, priceOptions } from "@/config/options";
 
 const drawer = ref(false);
 const showOnlyOpen = ref(false);
-
 const reloadMapTrigger = ref(0);
+
 const handleStoreRegistered = () => {
   reloadMapTrigger.value++;
 };
-
 const toggleSidebar = () => {
   drawer.value = !drawer.value;
 };

--- a/frontend/src/components/MapView.vue
+++ b/frontend/src/components/MapView.vue
@@ -176,7 +176,6 @@ const fetchStores = async () => {
    if (props.selectedReason) params.append("reason", props.selectedReason.toString());
 
    const url = `http://localhost:3000/api/stores?${params.toString()}`;
-   console.log("📡 取得URL:", url);
 
    const res = await fetch(url);
 

--- a/frontend/src/components/MapView.vue
+++ b/frontend/src/components/MapView.vue
@@ -178,6 +178,9 @@ const fetchStores = async () => {
    const url = `http://localhost:3000/api/stores?${params.toString()}`;
 
    const res = await fetch(url);
+   if (!res.ok) {
+     throw new Error(`HTTP error! status: ${res.status}`);
+   }
 
     stores.value = await res.json();
   } catch (err) {

--- a/frontend/src/components/RegisterSidebar.vue
+++ b/frontend/src/components/RegisterSidebar.vue
@@ -141,7 +141,7 @@ const selectPlace = async (place) => {
 
     const lat = details.geometry.location.lat();
     const lng = details.geometry.location.lng();
-    const jaAddress = await fetchJapaneseAddress(lat, lng); // ← awaitはOK
+    const jaAddress = await fetchJapaneseAddress(lat, lng);
 
     selectedPlace.value = {
       name: details.name,
@@ -153,7 +153,7 @@ const selectPlace = async (place) => {
     searchResults.value = [];
 };
 
-async function fetchJapaneseAddress(lat, lng) {
+const fetchJapaneseAddress = async (lat, lng) => {
   const res = await fetch(
     `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&language=ja&key=${API_KEY}`
   );
@@ -206,7 +206,7 @@ const registerStore = async () => {
   }
 };
 
-function convertTo24Hour(timeStr, suffix) {
+const convertTo24Hour = (timeStr, suffix) => {
   if (!timeStr || !suffix) {
     console.warn("Invalid time input:", timeStr, suffix);
     return "00:00";

--- a/frontend/src/components/RegisterSidebar.vue
+++ b/frontend/src/components/RegisterSidebar.vue
@@ -53,12 +53,12 @@
 
       <v-select
         v-model="price"
-        :items="priceOptions"
+        :items="priceOptionsForRegister"
         label="価格帯"
         dense
         class="mt-3"
-		:item-title="(item) => priceLabels[item]"
-        :item-value="(item) => item"
+		item-title="title"
+        item-value="value"
       />
 
       <v-btn color="success" block class="mt-4" @click="registerStore"
@@ -70,7 +70,7 @@
 
 <script setup>
 import { ref } from "vue";
-import { genreOptions, reasonOptions, priceOptions, priceLabels } from "@/config/options";
+import { genreOptions, reasonOptions, priceOptionsForRegister } from "@/config/options";
 
 
 const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;

--- a/frontend/src/components/RegisterSidebar.vue
+++ b/frontend/src/components/RegisterSidebar.vue
@@ -130,9 +130,10 @@ const selectPlace = async (place) => {
     return;
   }
 
-  loadMapReference();
+  try {
+    loadMapReference();
 
-  const details = await getDetailsPromise(place.place_id);
+    const details = await getDetailsPromise(place.place_id);
 
     if (!details.geometry || !details.name || !details.formatted_address) {
       alert("このお店の情報が不足しています。別のお店を選んでください。");
@@ -151,6 +152,10 @@ const selectPlace = async (place) => {
     };
 
     searchResults.value = [];
+  } catch (error) {
+    console.error("場所の詳細取得エラー:", error);
+    alert("場所の詳細を取得できませんでした。もう一度お試しください。");
+  }
 };
 
 const fetchJapaneseAddress = async (lat, lng) => {

--- a/frontend/src/components/RegisterSidebar.vue
+++ b/frontend/src/components/RegisterSidebar.vue
@@ -151,11 +151,6 @@ const selectPlace = async (place) => {
     };
 
     searchResults.value = [];
-
-    console.log(
-      "▶ opening_hours.weekday_text",
-      details.opening_hours?.weekday_text || "(none)",
-    );
 };
 
 async function fetchJapaneseAddress(lat, lng) {
@@ -163,7 +158,6 @@ async function fetchJapaneseAddress(lat, lng) {
     `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&language=ja&key=${API_KEY}`
   );
   const data = await res.json();
-  console.log("📦 Geocoding API レスポンス:", data); // ← 追加
   return data.results?.[0]?.formatted_address || "住所不明";
 }
 
@@ -297,7 +291,6 @@ const parseOpeningHours = (weekdayText) => {
       }
     }
 
-    console.log("▶ parseOpeningHours result:", result);
     return result;
   } catch (e) {
     console.error("parseOpeningHours で例外:", e);

--- a/frontend/src/components/RegisterSidebar.vue
+++ b/frontend/src/components/RegisterSidebar.vue
@@ -53,7 +53,7 @@
 
       <v-select
         v-model="price"
-        :items="priceOptionsForRegister"
+        :items="priceOptions"
         label="価格帯"
         dense
         class="mt-3"
@@ -70,7 +70,7 @@
 
 <script setup>
 import { ref } from "vue";
-import { genreOptions, reasonOptions, priceOptionsForRegister } from "@/config/options";
+import { genreOptions, reasonOptions, priceOptions } from "@/config/options";
 
 
 const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -1,32 +1,32 @@
 export function createMap(options) {
-  return options.reduce((acc, option) => {
-    acc[option.value] = option.title;
-    return acc;
-  }, {});
+    return options.reduce((acc, option) => {
+        acc[option.value] = option.title;
+        return acc;
+    }, {});
 }
 
 export const genreOptions = [
-  { title: '和食', value: 1 },
-  { title: '中華', value: 2 },
-  { title: '洋食', value: 3 },
-  { title: 'アジアン', value: 4 },
-  { title: 'カフェ', value: 5 },
-  { title: '居酒屋', value: 6 },
-  { title: 'その他', value: 7 },
+    { title: '和食', value: 1 },
+    { title: '中華', value: 2 },
+    { title: '洋食', value: 3 },
+    { title: 'アジアン', value: 4 },
+    { title: 'カフェ', value: 5 },
+    { title: '居酒屋', value: 6 },
+    { title: 'その他', value: 7 },
 ];
 
 export const reasonOptions = [
-  { title: 'コスパが良い', value: 1 },
-  { title: '提供が早い', value: 2 },
-  { title: '味が最高', value: 3 },
-  { title: '栄養満点', value: 4 },
+    { title: 'コスパが良い', value: 1 },
+    { title: '提供が早い', value: 2 },
+    { title: '味が最高', value: 3 },
+    { title: '栄養満点', value: 4 },
 ];
 
 export const priceOptions = [
-  { title: '~500', value: 1 },
-  { title: '~999', value: 2 },
-  { title: '~1500', value: 3 },
-  { title: '1501~', value: 4 },
+    { title: '~500', value: 1 },
+    { title: '~999', value: 2 },
+    { title: '~1500', value: 3 },
+    { title: '1501~', value: 4 },
 ];
 
 export const priceMap = createMap(priceOptions);

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -16,17 +16,17 @@ export const reasonOptions = [
 ];
 
 export const priceOptions = [
-  { title: "~500", value: 1 },
-  { title: "~999", value: 2 },
-  { title: "~1500", value: 3 },
-  { title: "1501~", value: 4 },
+    { title: '~500', value: 1 },
+    { title: '~999', value: 2 },
+    { title: '~1500', value: 3 },
+    { title: '1501~', value: 4 },
 ];
 
 export const priceOptionsForRegister = [
-  { title: "~500", value: 1 },
-  { title: "501~999", value: 2 },
-  { title: "1000~1500", value: 3 },
-  { title: "1501~", value: 4 },
+    { title: '~500', value: 1 },
+    { title: '501~999', value: 2 },
+    { title: '1000~1500', value: 3 },
+    { title: '1501~', value: 4 },
 ];
 
 export const genreMap = {

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -1,21 +1,28 @@
-export const genreOptions = [
-    { title: '和食', value: 1 },
-    { title: '中華', value: 2 },
-    { title: '洋食', value: 3 },
-    { title: 'アジアン', value: 4 },
-    { title: 'カフェ', value: 5 },
-    { title: '居酒屋', value: 6 },
-    { title: 'その他', value: 7 },
-];
+export function createMap(options) {
+  return options.reduce((acc, option) => {
+    acc[option.value] = option.title;
+    return acc;
+  }, {});
+}
 
+export const genreOptions = [
+  { title: '和食', value: 1 },
+  { title: '中華', value: 2 },
+  { title: '洋食', value: 3 },
+  { title: 'アジアン', value: 4 },
+  { title: 'カフェ', value: 5 },
+  { title: '居酒屋', value: 6 },
+  { title: 'その他', value: 7 },
+];
 export const reasonOptions = [
-    { title: 'コスパが良い', value: 1 },
-    { title: '提供が早い', value: 2 },
-    { title: '味が最高', value: 3 },
-    { title: '栄養満点', value: 4 },
+  { title: 'コスパが良い', value: 1 },
+  { title: '提供が早い', value: 2 },
+  { title: '味が最高', value: 3 },
+  { title: '栄養満点', value: 4 },
 ];
 
 export const priceOptions = [
+<<<<<<< HEAD
     { title: '~500', value: 1 },
     { title: '~999', value: 2 },
     { title: '~1500', value: 3 },
@@ -52,3 +59,14 @@ export const priceMap = {
     3: '1000~1500',
     4: '1501~',
 };
+=======
+  { title: '~500', value: 1 },
+  { title: '~999', value: 2 },
+  { title: '~1500', value: 3 },
+  { title: '1501~', value: 4 },
+];
+
+export const priceMap = createMap(priceOptions);
+export const reasonMap = createMap(reasonOptions);
+export const genreMap = createMap(genreOptions);
+>>>>>>> 11dc39a (MapとOptionsそれぞれ別で定義していた絞り込み要件をOptionsに統合して、MapはOptionsをCreateMapすることで使用するよう変更した)

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -22,12 +22,12 @@ export const priceOptions = [
   { title: "1501~", value: 4 },
 ];
 
-export const priceLabels = {
-    1: '~500',
-    2: '501~999',
-    3: '1000~1500',
-    4: '1501~',
-};
+export const priceOptionsForRegister = [
+  { title: "~500", value: 1 },
+  { title: "501~999", value: 2 },
+  { title: "1000~1500", value: 3 },
+  { title: "1501~", value: 4 },
+];
 
 export const genreMap = {
     1: '和食',

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -1,4 +1,4 @@
-export function createMap(options) {
+const createMap = (options) => {
     return options.reduce((acc, option) => {
         acc[option.value] = option.title;
         return acc;

--- a/frontend/src/config/options.js
+++ b/frontend/src/config/options.js
@@ -3,7 +3,7 @@ const createMap = (options) => {
         acc[option.value] = option.title;
         return acc;
     }, {});
-}
+};
 
 export const genreOptions = [
     { title: '和食', value: 1 },


### PR DESCRIPTION
# 概要
価格帯の登録時の表示がバグっていたのを適切な表示になるように修正
# 変更箇所
登録時の価格表示と絞り込みの価格表示の仕方が違うので、それぞれ別にした
登録時は
~500
501~999
1000~1500
1501~
絞り込みするときは
~500
~999
~1500
1501~
# 影響範囲
- [x] frontend
- [ ] backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the price selection dropdown in the registration sidebar with clearer and more precise price range options.  
  - Improved the underlying option mappings for genre, reason, and price selections to ensure consistent display and selection behavior.
- **Bug Fixes**
  - Enhanced error handling for map loading and place details retrieval with user alerts on failure.
  - Added HTTP response status checks for store data fetching to handle request errors gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->